### PR TITLE
Update ha_gateway.rb

### DIFF
--- a/ha_gateway.rb
+++ b/ha_gateway.rb
@@ -1,13 +1,9 @@
 require 'sinatra'
 require 'ledenet_api'
-require 'color'
 require 'openssl'
 
 require_relative 'config_provider'
-
-RGB_PARAMS = ['r', 'g', 'b']
 config_provider = HaGateway::CachingConfigProvider.new(HaGateway::ConfigProvider.new)
-api = LEDENET::Api.new(config_provider.ledenet_host)
 
 before do
   timestamp = request.env['HTTP_X_SIGNATURE_TIMESTAMP']
@@ -27,26 +23,205 @@ end
 post '/leds' do
   puts params.inspect
 
-  if params['status'] == 'on'
-    api.on
-  elsif params['status'] == 'off'
-    api.off
+  api = LEDENET::Api.new(params['ip'])
+    # Set Power Status
+    if params['status'] == 'on' || params['switch'] == 'on'
+      api.on
+    elsif params['status'] == 'off' || params['switch'] == 'off'
+      api.off
+    end
+
+    r,g,b,w,powerState = api.current_status
+    h,s,l = rgbToHsv(r,g,b)
+
+    # Is the device a Magic UFO?
+    if params['deviceType'].casecmp("UFO").zero?
+      # Adjust HSL only
+      if params.include?('hue') && params.include?('saturation') && params.include?('level')
+        r,g,b = hsvToRgb((params['hue'].to_f*3.6),params['saturation'].to_f,params['level'].to_f)
+        api.update_ufo(r,g,b,w, false)
+      end
+      # Adjust level only
+      if params.include?('level') && !params.include?('hue') && !params.include?('saturation') 
+        h,s,l = rgbToHsv(r,g,b)
+        r,g,b = hsvToRgb(h,s,(params['level'].to_i))
+        api.update_ufo(r,g,b,w, false) 
+      end
+      # Adjust saturation only
+      if params.include?('saturation') && !params.include?('hue') && !params.include?('level') 
+        h,s,v = rgbToHsv(r,g,b)
+        r,g,b = hsvToRgb(h,params['saturation'].to_f,v)
+        api.update_ufo(r,g,b,w, false)
+      end
+      # Adjust hue only
+      if params.include?('hue') && !params.include?('saturation') && !params.include?('level') 
+        h,s,v = rgbToHsv(r,g,b)
+        r,g,b = hsvToRgb(params['hue'].to_f,s,v)
+        api.update_ufo(r,g,b,w, false)
+      end
+      # Adjust Warm White only
+      if params.include?('UFOWWLevel') && !params.include?('saturation') && !params.include?('level') && !params.include?('hue')
+        api.update_ufo(r,g,b,params['UFOWWLevel'].to_i*2.55, false)
+      
+      end
+    else # Adjust a bulb
+      # Adjust HSL
+      if params.include?('hue') && params.include?('saturation') && params.include?('level')
+        # If H & S from ST are the WW button's level, enable WW
+        if params['hue'] == "16.66666666666666" && params['saturation'] == "27.45097875595093"
+          w = params['level'].to_i*2.55 # Convert from 0-100 to 0-255
+          api.update_bulb_white(w,false)
+        else
+          r,g,b = hsvToRgb(params['hue'].to_f*3.6, params['saturation'].to_f, params['level'].to_f)
+          api.update_bulb_color(r,g,b, false)
+        end
+      end
+      # Adjust level only
+      if params.include?('level') && !params.include?('hue') && !params.include?('saturation') 
+        # If colors are off, adjust WW
+        if [r,g,b] == [0,0,0]
+          w = params['level'].to_i*2.55 #Convert from 0-100 to 0-255
+          api.update_bulb_white(w,false)
+        else
+          h,s,v = rgbToHsv(r,g,b)
+          r,g,b = hsvToRgb(h,s,params['level'].to_i*2.55)
+          api.update_bulb_color(r,g,b, false)
+        end
+      end
+      # Adjust saturation only
+      if params.include?('saturation') && !params.include?('hue') && !params.include?('level') 
+        # Get the bulb's hue and level, if in WW mode
+        if [r,g,b] == [0,0,0] && w > 0
+          r,g,b = hsvToRgb(60.0,27.45097875595093,w/2.55)
+        end
+        h,s,v = rgbToHsv(r,g,b)
+        r,g,b = hsvToRgb(h,params['saturation'].to_f,v)
+        api.update_bulb_color(r,g,b, false)
+      end
+      # Adjust hue only
+      if params.include?('hue') && !params.include?('saturation') && !params.include?('level') 
+        # Get the bulb's hue and level, if in WW mode
+        if [r,g,b] == [0,0,0] && w > 0
+          r,g,b = hsvToRgb(60.0,27.45097875595093,w/2.55)
+        end
+        h,s,v = rgbToHsv(r,g,b)
+        r,g,b = hsvToRgb(params['hue'].to_f,s,v)
+        api.update_bulb_color(r,g,b, false)
+      end
+    end
+
+    r,g,b,w,powerState = api.current_status # Get new settings from the device
+    h,s,l = rgbToHsv(r,g,b)
+
+    if !params['deviceType'].casecmp("UFO").zero? # If the device isn't a UFO, set the RGB to what WW's H & S are
+      if [r,g,b] == [0,0,0] && w > 0
+        r,g,b = hsvToRgb(16.66666666666666, 27.45097875595093, (w/2.55))
+      end
+      status 200
+      headers \
+        "powerState" => powerState,
+        "level" => l.to_s,
+        "hex" => "#" + to_hex(r) + to_hex(g) + to_hex(b)
+
+    else # If the device is a UFO, change the other parameters.
+      status 200
+      headers \
+        "powerState" => powerState,
+        "level" => l.to_s,
+        "hex" =>  "#" + to_hex(r) + to_hex(g) + to_hex(b),
+        "UFOWWLevel" => (w/2.55).to_s
+    end
+    status 200
+    body '{"success": true}'
+end
+def rgbToHsv(r, g, b)
+  # Takes an RGB value (0-255) and returns HSV in 0-360, 0-100, 0-100
+  r /= 255.0
+  g /= 255.0
+  b /= 255.0
+
+  max = [r, g, b].max.to_f
+  min = [r, g, b].min.to_f
+  delta = (max - min).to_f
+  v = (max * 100.0).to_f
+
+  max != 0.0 ? s = delta / max * 100.0 : s=0
+  
+  if (s == 0.0) 
+    h = 0.0
+  else
+      if (r == max)
+        h = ((g - b) / delta).to_f
+      elsif (g == max)
+        h = (2 + (b - r) / delta).to_f
+      elsif (b == max)
+        h = (4 + (r - g) / delta).to_f
+    end
+    h *= 60.0
+    h += 360 if (h < 0)
+  end
+  return h,s,v
+end
+def hsvToRgb(h,s,v)
+  h /= 360.0
+  s /= 100.0
+  v /= 100.0
+
+  if s == 0.0
+     r = v * 255
+     g = v * 255
+     b = v * 255
+  else
+    h = (h * 6).to_f
+    h = 0 if h == 6
+    i = h.floor
+    var_1 = (v * ( 1.0 - s )).to_f
+    var_2 = (v * ( 1.0 - s * ( h - i ) )).to_f
+    var_3 = (v * ( 1.0 - s * ( 1.0 - ( h - i )))).to_f
   end
 
-  if (RGB_PARAMS & params.keys) == RGB_PARAMS
-    rgb = RGB_PARAMS.map { |x| params[x].to_i }
-    api.update_color(*rgb)
+  if i == 0 
+    r = v
+    g = var_3
+    b = var_1
+  elsif i == 1
+    r = var_2
+    g = v
+    b = var_1
+  elsif i == 2
+    r = var_1
+    g = v
+    b = var_3
+  elsif i == 3
+    r = var_1
+    g = var_2
+    b = v
+  elsif i == 4
+    r = var_3
+    g = var_1
+    b = v
+  else
+    r = v
+    g = var_1
+    b = var_2
   end
 
-  if params.include?('level')
-    hsl_color = Color::RGB.new(*api.current_color).to_hsl
-    hsl_color.luminosity = params['level'].to_i
+    if r==nil
+      r=0
+    end
+    if g==nil
+      g=0
+    end
+    if b==nil
+      b=0
+    end
 
-    adjusted_rgb = hsl_color.to_rgb.to_a.map { |x| (x * 255).to_i }
+    r *= 255
+    g *= 255
+    b *= 255
 
-    api.update_color(*adjusted_rgb)
-  end
-
-  status 200
-  body '{"success": true}'
+  return r.to_i, g.to_i, b.to_i
+end
+def to_hex(number)
+  number.to_s(16).upcase.rjust(2, '0')
 end


### PR DESCRIPTION
##### This update makes many changes for use in conjunction with [my updated SmartThings device type](https://gist.github.com/adamkempenich/41faf3bb461b8a0b3bd3). It also adds support for bulbs and WW support on the Magic Home ("LEDeNet") UFO.
### This PR includes the following changes:
- _[Removed]_ require Color. I've manually added color conversion code to handle the removal.
- _[Changed]_ IP handling. This method pulls a static IP from a SmartThings device's configuration as opposed to using the LEDeNet API to find the first LEDeNet device on a network (allows for multiple devices).
- _[Changed]_ On/Off handling now supports methods that pass [status] or [switch](some smart apps do this)
- _[Changed]_ Color handling now detects and changes color using HSV, H, S, V, or WW. Additionally, it detects which type of device is being handled to manage these colors for the device's specs.
- _[Changed]_ HTTP headers are sent back to ST for refreshing the device's state to match a bulb's settings (in case someone uses the app to update it, etc...)
- _[Changed]_ Previously, the gateway used HSL. It's been corrected to use HSV, now.
#### Notes:
- Since the new SmartThings Device Type uses a multitile, it has a button for Warm White and Cool White. WW sends a hue of 16.6% and a saturation of ~27.45%. If these values are received, WW mode is enabled.
#### Bugs:
- For some reason, the color #FFFFFF will actually change the color to #FF0000. I have an idea of why this happens, but have yet to fix it.
- There are definitely more bugs... haven't found them all, though.
#### To-do:
- Some bulbs accept a cool white value (I think?). If we receive #FFFFFF, CW should be enabled.
- Add a mode to auto-detect the type of device at the assigned IP.
- Add color fading.
- Add support for RGB-only devices, or White-Only devices.
##### Let me know if you have any questions or requests. I'm actively working on this code to add new features, but wanted to get it sent over for you to take a look. Since this is meant to be used in conjunction with [my updated SmartThings device type](https://gist.github.com/adamkempenich/41faf3bb461b8a0b3bd3), feel free to take a look at that, as well.
